### PR TITLE
Add smoke image and toggling to custom

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -121,12 +121,16 @@ struct key_container {
 };
 
 std::vector<key_container> key_containers;
-sf::Sprite bg, mouse;
+sf::Sprite bg, mouse, smoke;
+Json::Value smoke_key_value;
 
-bool is_mouse, is_mouse_on_top;
+bool is_mouse, is_mouse_on_top, is_enable_toggle_smoke;
 int offset_x, offset_y, scale;
 int paw_r, paw_g, paw_b, paw_a;
 int paw_edge_r, paw_edge_g, paw_edge_b, paw_edge_a;
+bool previous_smoke_key_state = false;
+bool current_smoke_key_state = false;
+bool is_toggle_smoke = false;
 
 bool init() {
     // getting configs
@@ -166,6 +170,10 @@ bool init() {
             }
             mouse.setTexture(data::load_texture(custom["mouseImage"].asString()));
         }
+
+        smoke_key_value = custom["smoke"];
+        is_enable_toggle_smoke = custom["toggleSmoke"].asBool();
+        smoke.setTexture(data::load_texture(custom["smokeImage"].asString()));
     } catch (...) {
         return false;
     }
@@ -331,6 +339,34 @@ void draw() {
     // drawing mouse at the bottom
     if (is_mouse && !is_mouse_on_top) {
         window.draw(mouse);
+    }
+
+    // draw smoke
+    bool is_smoke_key_pressed = false;
+
+    for (Json::Value &v : smoke_key_value) {
+        if (input::is_pressed(v.asInt())) {
+            is_smoke_key_pressed = true;
+            break;
+        }
+    }
+
+    if (is_enable_toggle_smoke) {
+        previous_smoke_key_state = current_smoke_key_state;
+        current_smoke_key_state = is_smoke_key_pressed;
+
+        bool is_smoke_key_down = current_smoke_key_state && (current_smoke_key_state != previous_smoke_key_state);
+
+        if (is_smoke_key_down) {
+            is_toggle_smoke = !is_toggle_smoke;
+        }
+    }
+    else {
+        is_toggle_smoke = is_smoke_key_pressed;
+    }
+
+    if (is_toggle_smoke) {
+        window.draw(smoke);
     }
 }
 }; // namespace custom

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -70,10 +70,7 @@ void create_config() {
         "scalar": 1.0,
         "paw": [255, 255, 255],
         "pawEdge": [0, 0, 0],
-        "keyContainers": [],
-        "smoke": [67],
-        "smokeImage": "img/osu/smoke.png",
-        "toggleSmoke": false
+        "keyContainers": []
     },
     "mousePaw": {
         "mousePawComment": "coordinates start in the top left of the window",

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -19,7 +19,7 @@ std::map<std::string, sf::Texture> img_holder;
 void create_config() {
     const char *s =
         R"V0G0N({
-    "mode": 5,
+    "mode": 1,
     "resolution": {
         "letterboxing": false,
         "width": 1920,

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -19,7 +19,7 @@ std::map<std::string, sf::Texture> img_holder;
 void create_config() {
     const char *s =
         R"V0G0N({
-    "mode": 1,
+    "mode": 5,
     "resolution": {
         "letterboxing": false,
         "width": 1920,
@@ -70,7 +70,10 @@ void create_config() {
         "scalar": 1.0,
         "paw": [255, 255, 255],
         "pawEdge": [0, 0, 0],
-        "keyContainers": []
+        "keyContainers": [],
+        "smoke": [67],
+        "smokeImage": "img/osu/smoke.png",
+        "toggleSmoke": false
     },
     "mousePaw": {
         "mousePawComment": "coordinates start in the top left of the window",


### PR DESCRIPTION
Added these properties for `custom`:
- `smokeImage`: the smoke image
- `smokeKey`: array of keys to toggle smoke image
- `toggleSmoke`: like `osu` mode, if it is false, the smoke image will appear as long as you hold the smoke key, otherwise it'll toggle between being visible and being invisible everytime you press the smoke key.