### PR TITLE
Window size customization

### DIFF
--- a/include/header.hpp
+++ b/include/header.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #define BONGO_KEYPRESS_THRESHOLD 0
-#define WINDOW_WIDTH 612
-#define WINDOW_HEIGHT 352
+#define BASE_WIDTH 612
+#define BASE_HEIGHT 352
 #define MAX_FRAMERATE 60
 
 #include <iostream>
@@ -51,29 +51,29 @@ void cleanup();
 namespace osu {
 bool init();
 
-void draw();
+void draw(const sf::RenderStates& rstates);
 }; // namespace osu
 
 namespace taiko {
 bool init();
 
-void draw();
+void draw(const sf::RenderStates& rstates);
 }; // namespace taiko
 
 namespace ctb {
 bool init();
 
-void draw();
+void draw(const sf::RenderStates& rstates);
 }; // namespace ctb
 
 namespace mania {
 bool init();
 
-void draw();
+void draw(const sf::RenderStates& rstates);
 }; // namespace mania
 
 namespace custom {
 bool init();
 
-void draw();
+void draw(const sf::RenderStates& rstates);
 }; // namespace custom

--- a/src/ctb.cpp
+++ b/src/ctb.cpp
@@ -40,7 +40,7 @@ bool init() {
     return true;
 }
 
-void draw() {
+void draw(const sf::RenderStates& rstates) {
     window.draw(bg);
     
     // drawing left-right keypresses
@@ -78,34 +78,34 @@ void draw() {
 
     if (!left_key_state && !right_key_state) {
         key_state = 0;
-        window.draw(mid);
+        window.draw(mid, rstates);
     }
     if (key_state == 1) {
         if ((clock() - timer_right_key) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
-            window.draw(left);
+            window.draw(left, rstates);
             timer_left_key = clock();
         } else {
-            window.draw(mid);
+            window.draw(mid, rstates);
         }
     } else if (key_state == 2) {
         if ((clock() - timer_left_key) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
-            window.draw(right);
+            window.draw(right, rstates);
             timer_right_key = clock();
         } else {
-            window.draw(mid);
+            window.draw(mid, rstates);
         }
     }
 
     bool is_dash = false;
     for (Json::Value &v : dash_key_value) {
         if (input::is_pressed(v.asInt())) {
-            window.draw(dash);
+            window.draw(dash, rstates);
             is_dash = true;
             break;
         }
     }
     if (!is_dash) {
-        window.draw(up);
+        window.draw(up, rstates);
     }
 }
 }; // namespace ctb

--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -52,8 +52,8 @@ struct key {
         return false;
     }
 
-    void draw() {
-        window.draw(sprite);
+    void draw(const sf::RenderStates& rstates) {
+        window.draw(sprite, rstates);
         timer = clock();
     }
 };
@@ -85,7 +85,7 @@ struct key_container {
         }
     }
 
-    void draw() {
+    void draw(const sf::RenderStates& rstates) {
         bool is_any_key_pressed = false;
         for (int i = 0; i < keys.size(); i++) {
             key& current_key = keys[i];
@@ -101,7 +101,7 @@ struct key_container {
         }
         if (!is_any_key_pressed) {
             key_state = -1;
-            window.draw(default_sprite);
+            window.draw(default_sprite, rstates);
         }
         if (key_state > -1) {
             key& on_key = keys[key_state];
@@ -112,9 +112,9 @@ struct key_container {
                 }
             }
             if ((clock() - last_press) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
-                on_key.draw();
+                on_key.draw(rstates);
             } else {
-                window.draw(default_sprite);
+                window.draw(default_sprite, rstates);
             }
         }
     }
@@ -172,7 +172,7 @@ bool init() {
     return true;
 }
 
-void draw() {
+void draw(const sf::RenderStates& rstates) {
     window.draw(bg);
 
     if (is_mouse) {
@@ -181,6 +181,8 @@ void draw() {
         int x_paw_start = paw_draw_info["pawStartingPoint"][0].asInt();
         int y_paw_start = paw_draw_info["pawStartingPoint"][1].asInt();
         auto [x, y] = input::get_xy();
+        // Add extra custom height from the base height this bezier calculation is based on
+        y += data::cfg["decoration"]["window_height"].asInt() - BASE_HEIGHT;
         int oof = 6;
         std::vector<double> pss = {(float) x_paw_start, (float) y_paw_start};
         double dist = hypot(x_paw_start - x, y_paw_start - y);
@@ -325,7 +327,7 @@ void draw() {
     }
 
     for (key_container& current : key_containers) {
-        current.draw();
+        current.draw(rstates);
     }
 
     // drawing mouse at the bottom

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -28,6 +28,8 @@ void create_config() {
         "verticalPosition": 0
     },
     "decoration": {
+        "window_width": 612,
+        "window_height": 352,
         "leftHanded": false,
         "rgb": [255, 255, 255],
         "offsetX": [0, 11],

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -166,7 +166,7 @@ bool init() {
     }
 
     // initialize debug resource
-    debugBackground.setSize(sf::Vector2f(WINDOW_WIDTH, WINDOW_HEIGHT));
+    debugBackground.setSize(sf::Vector2f(data::cfg["decoration"]["window_width"].asInt(), data::cfg["decoration"]["window_height"].asInt()));
     debugBackground.setFillColor(sf::Color(0, 0, 0, 128));
 
     debugText.setFont(debugFont);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,13 +12,16 @@ int main(int argc, char ** argv) {
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 #endif
 
-    window.create(sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), "Bongo Cat for osu!", sf::Style::Titlebar | sf::Style::Close);
-    window.setFramerateLimit(MAX_FRAMERATE);
-
     // loading configs
     while (!data::init()) {
         continue;
     }
+
+    Json::Value windowWidth = data::cfg["decoration"]["window_width"];
+    Json::Value windowHeight = data::cfg["decoration"]["window_height"];
+    window.create(sf::VideoMode(windowWidth.asInt(), windowHeight.asInt()), "Bongo Cat for osu!", sf::Style::Titlebar | sf::Style::Close);
+    window.setFramerateLimit(MAX_FRAMERATE);
+
 
     // initialize input
     if (!input::init()) {
@@ -67,22 +70,27 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
         int blue_value = rgb[2].asInt();
         int alpha_value = rgb.size() == 3 ? 255 : rgb[3].asInt();
 
+        // Translation for artifacts when resize is applied
+        sf::Transform transform = sf::Transform();
+        transform.translate(0, windowHeight.asInt()-BASE_HEIGHT);
+        sf::RenderStates rstates = sf::RenderStates(transform);
+
         window.clear(sf::Color(red_value, green_value, blue_value, alpha_value));
         switch (mode) {
         case 1:
-            osu::draw();
+            osu::draw(rstates);
             break;
         case 2:
-            taiko::draw();
+            taiko::draw(rstates);
             break;
         case 3:
-            ctb::draw();
+            ctb::draw(rstates);
             break;
         case 4:
-            mania::draw();
+            mania::draw(rstates);
             break;
         case 5:
-            custom::draw();
+            custom::draw(rstates);
         }
 
         if (is_show_input_debug) {

--- a/src/mania.cpp
+++ b/src/mania.cpp
@@ -56,7 +56,7 @@ bool init() {
     return true;
 }
 
-void draw_4K() {
+void draw_4K(const sf::RenderStates& rstates) {
     window.draw(bg);
 
     int left_cnt = 0, right_cnt = 0;
@@ -64,12 +64,12 @@ void draw_4K() {
 
     for (int i = 0; i < 2; i++) {
         if (input::is_pressed(left_key_value_4K[i])) {
-            window.draw(left_4K[i]);
+            window.draw(left_4K[i], rstates);
             left_cnt++;
             left_sum += i;
         }
         if (input::is_pressed(right_key_value_4K[i])) {
-            window.draw(right_4K[i]);
+            window.draw(right_4K[i], rstates);
             right_cnt++;
             right_sum += i;
         }
@@ -77,34 +77,34 @@ void draw_4K() {
 
     // draw left hand
     if (left_cnt == 0) {
-        window.draw(left_handup);
+        window.draw(left_handup, rstates);
     } else {
         double avg = 1.0 * left_sum / left_cnt;
         if (avg == 0) {
-            window.draw(left_hand[0]);
+            window.draw(left_hand[0], rstates);
         } else if (avg == 0.5) {
-            window.draw(left_hand[1]);
+            window.draw(left_hand[1], rstates);
         } else {
-            window.draw(left_hand[2]);
+            window.draw(left_hand[2], rstates);
         }
     }
 
     // draw right hand
     if (right_cnt == 0) {
-        window.draw(right_handup);
+        window.draw(right_handup, rstates);
     } else {
         double avg = 1.0 * right_sum / right_cnt;
         if (avg == 0) {
-            window.draw(right_hand[0]);
+            window.draw(right_hand[0], rstates);
         } else if (avg == 0.5) {
-            window.draw(right_hand[1]);
+            window.draw(right_hand[1], rstates);
         } else {
-            window.draw(right_hand[2]);
+            window.draw(right_hand[2], rstates);
         }
     }
 }
 
-void draw_7K() {
+void draw_7K(const sf::RenderStates& rstates) {
     window.draw(bg);
 
     int left_cnt = 0, right_cnt = 0;
@@ -112,12 +112,12 @@ void draw_7K() {
 
     for (int i = 0; i < 4; i++) {
         if (input::is_pressed(left_key_value_7K[i])) {
-            window.draw(left_7K[i]);
+            window.draw(left_7K[i], rstates);
             left_cnt++;
             left_sum += i;
         }
         if (input::is_pressed(right_key_value_7K[i])) {
-            window.draw(right_7K[i]);
+            window.draw(right_7K[i], rstates);
             right_cnt++;
             right_sum += i;
         }
@@ -125,38 +125,38 @@ void draw_7K() {
 
     // draw left hand
     if (left_cnt == 0) {
-        window.draw(left_handup);
+        window.draw(left_handup, rstates);
     } else {
         double avg = 1.0 * left_sum / left_cnt;
         if (avg < 1.0) {
-            window.draw(left_hand[0]);
+            window.draw(left_hand[0], rstates);
         } else if (avg <= 2.0) {
-            window.draw(left_hand[1]);
+            window.draw(left_hand[1], rstates);
         } else {
-            window.draw(left_hand[2]);
+            window.draw(left_hand[2], rstates);
         }
     }
 
     // draw right hand
     if (right_cnt == 0) {
-        window.draw(right_handup);
+        window.draw(right_handup, rstates);
     } else {
         double avg = 1.0 * right_sum / right_cnt;
         if (avg < 1.0) {
-            window.draw(right_hand[0]);
+            window.draw(right_hand[0], rstates);
         } else if (avg <= 2.0) {
-            window.draw(right_hand[1]);
+            window.draw(right_hand[1], rstates);
         } else {
-            window.draw(right_hand[2]);
+            window.draw(right_hand[2], rstates);
         }
     }
 }
 
-void draw() {
+void draw(const sf::RenderStates& rstates) {
     if (is_4K) {
-        draw_4K();
+        draw_4K(rstates);
     } else {
-        draw_7K();
+        draw_7K(rstates);
     }
 }
 }; // namespace mania

--- a/src/osu.cpp
+++ b/src/osu.cpp
@@ -90,7 +90,7 @@ bool init() {
     return true;
 }
 
-void draw() {
+void draw(const sf::RenderStates& rstates) {
     window.draw(bg);
 
     // initializing pss and pss2 (kuvster's magic)
@@ -98,6 +98,7 @@ void draw() {
     int x_paw_start = paw_draw_info["pawStartingPoint"][0].asInt();
     int y_paw_start = paw_draw_info["pawStartingPoint"][1].asInt();
     auto [x, y] = input::get_xy();
+    y += data::cfg["decoration"]["window_height"].asInt() - BASE_HEIGHT;
     int oof = 6;
     std::vector<double> pss = {(float) x_paw_start, (float) y_paw_start};
     double dist = hypot(x_paw_start - x, y_paw_start - y);
@@ -297,37 +298,37 @@ void draw() {
 
     if (!left_key_state && !right_key_state && !wave_key_state) {
         key_state = 0;
-        window.draw(up);
+        window.draw(up, rstates);
     }
 
     if (key_state == 1) {
         if ((clock() - std::max(timer_right_key, timer_wave_key)) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
             if (!is_left_handed) {
-                window.draw(left);
+                window.draw(left, rstates);
             } else {
-                window.draw(right);
+                window.draw(right, rstates);
             }
             timer_left_key = clock();
         } else {
-            window.draw(up);
+            window.draw(up, rstates);
         }
     } else if (key_state == 2) {
         if ((clock() - std::max(timer_left_key, timer_wave_key)) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
             if (!is_left_handed) {
-                window.draw(right);
+                window.draw(right, rstates);
             } else {
-                window.draw(left);
+                window.draw(left, rstates);
             }
             timer_right_key = clock();
         } else {
-            window.draw(up);
+            window.draw(up, rstates);
         }
     } else if (key_state == 3) {
         if ((clock() - std::max(timer_left_key, timer_right_key)) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
-            window.draw(wave);
+            window.draw(wave, rstates);
             timer_wave_key = clock();
         } else {
-            window.draw(up);
+            window.draw(up, rstates);
         }
     }
 
@@ -361,7 +362,7 @@ void draw() {
     }
 
     if (is_toggle_smoke) {
-        window.draw(smoke);
+        window.draw(smoke, rstates);
     }
 }
 }; // namespace osu

--- a/src/taiko.cpp
+++ b/src/taiko.cpp
@@ -53,7 +53,7 @@ bool init() {
     return true;
 }
 
-void draw() {
+void draw(const sf::RenderStates& rstates) {
     window.draw(bg);
 
     // 0 for left side, 1 for right side
@@ -92,21 +92,21 @@ void draw() {
 
         if (!rim_key_state[i] && !centre_key_state[i]) {
             key_state[i] = 0;
-            window.draw(up[i]);
+            window.draw(up[i], rstates);
         }
         if (key_state[i] == 1) {
             if ((clock() - timer_centre_key[i]) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
-                window.draw(rim[i]);
+                window.draw(rim[i], rstates);
                 timer_rim_key[i] = clock();
             } else {
-                window.draw(up[i]);
+                window.draw(up[i], rstates);
             }
         } else if (key_state[i] == 2) {
             if ((clock() - timer_rim_key[i]) / CLOCKS_PER_SEC > BONGO_KEYPRESS_THRESHOLD) {
-                window.draw(centre[i]);
+                window.draw(centre[i], rstates);
                 timer_centre_key[i] = clock();
             } else {
-                window.draw(up[i]);
+                window.draw(up[i], rstates);
             }
         }
     }


### PR DESCRIPTION
Resolves #60 
I have changed the fixed size to a custom one.
The base height and width is still there because it was the easier way to modify the bezier calculation.

Window size is established on config.json and this gives some space so a bigger background can be rendered in all game modes.
The user has to fine-tune other configuration parameters for this to work as intended, pawsStart and ending points have to be adjusted with the new height. Other artifacts that don't use the bezier calculation will be pushed down and should keep their standard dimensions to be adequately rendered.

Note: The wobbly line between the keyboard and mousepad is a result of my image editing skills, not related to code, the skin is like that 😆 .
![image](https://user-images.githubusercontent.com/36534958/190709269-83932837-40b8-45ac-b625-d09708217287.png)

In this example I used an increased height of 260 (612 pixels x 612 pixels window) so I had to modify the pawPoints in the config.json like this:
`        "pawStartingPoint": [211, 419],
        "pawEndingPoint": [258, 488]
`

Mode 2 example with increased width too:
![image](https://user-images.githubusercontent.com/36534958/190710009-48d17eaa-b4d7-4a35-9f64-024fb193e6e5.png)
