### PR TITLE
Fixed mouse position for 3D fps games that center the mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ First, it detects if your mouse is being centered on your screen. If it is, then
 "fpsReturnSpeed" : 50
 ```
 
-"fpsSensitivity" controls how fast the bongocat's mouse moves.
+"fpsSensitivity" controls how sensitive the bongocat's mouse is to your movements.
 
 "fpsReturnSpeed" controls how fast the bongocat's mouse returns to the center after you let go of your mouse.

--- a/README.md
+++ b/README.md
@@ -1,60 +1,17 @@
 # Description
-An osu! Bongo Cat overlay with smooth paw movement and simple skinning ability, written in C++. Originally created by [HamishDuncanson](https://github.com/HamishDuncanson).
 
-You can find how to configure the application in our [wiki](https://github.com/kuroni/bongocat-osu/wiki/Settings).
+This repository expands on [bongocat-osu ](https://github.com/kuroni/bongocat-osu) by making the mouse work in 3D FPS games such as Counter Strike. 
+These previously didn't work with bongocat because these games take control of your cursor and center it on your screen.
 
-Download the program [here](https://github.com/kuroni/bongocat-osu/releases).
+First, it detects if your mouse is being centered on your screen. If it is, then the application switches to "raw input" - relative movements of the mouse affect the position of bongocat's mouse, as opposed to the "absolute" position of your cursor. Because we can't detect if mouse has been lifted, if you let go of the mouse, the virtual mouse drifts back to the center. 
 
-Hugs and kisses to [CSaratakij](https://github.com/CSaratakij) for creating the Linux port for this project!
+# Config
 
-Any suggestion and/or collaboration, especially that relating to sprites, is welcomed! Thank you!
-
-[Original post](https://www.reddit.com/r/osugame/comments/9hrkte/i_know_bongo_cat_is_getting_old_but_heres_a_nicer/) by [Kuvster](https://github.com/Kuvster).
-
-## Further information
-In order to play with fullscreen on Windows 10, run both osu! and this application in Windows 7 compability mode.
-
-Press Ctrl + R to reload configuration and images (will only reload configurations when the window is focused).
-
-Supported operating system:
-* Windows
-* Linux (tested with Arch Linux with WINE Staging 5). Note: You **must** use WINE Staging, because for whatever reason on stable WINE bongocat-osu doesn't register keyboard input from other windows.
-
-_Notice_: If you're using WINE on Linux, make sure that osu! and this application run in the same `WINEPREFIX`.
-
-## For developers
-This project uses [SFML](https://www.sfml-dev.org/index.php) and [JsonCpp](https://github.com/open-source-parsers/jsoncpp). JsonCpp libraries are directly included in the source using the provided `amalgamation.py` from the developers.
-
-### Libraries and dependency
-
-#### Windows and MinGW
-To build the source, download the SFML libraries [here](https://www.sfml-dev.org/index.php), copy `Makefile.windows` to `Makefile`, then replace *`<SFML-folder>`* in `Makefile` with the desired folder.
-
-#### Linux
-You need to have these dependencies installed. Check with your package manager for the exact name of these dependencies on your distro:
-- g++
-- libxdo
-- sdl2
-- sfml
-- x11
-- xrandr
-
-Then, copy `Makefile.linux` to `Makefile`.
-
-### Building and testing
-To build, run this command from the base directory:
-
-```sh
-make
+```json
+"fpsSensitivity" : 2.0,
+"fpsReturnSpeed" : 50
 ```
 
-To test the program, run this from the base directory:
+"fpsSensitivity" controls how fast the bongocat's mouse moves.
 
-```sh
-make test
-```
-
-Alternatively, you can copy the newly-compiled `bin/bongo.exe` or `bin/bongo` into the base directory and execute it.
-
-If you have troubles compiling, it can be due to version mismatch between your compiler and SFML. See [#43](https://github.com/kuroni/bongocat-osu/issues/43) for more information.
-
+"fpsReturnSpeed" controls how fast the bongocat's mouse returns to the center after you let go of your mouse.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository expands on [bongocat-osu ](https://github.com/kuroni/bongocat-osu) by making the mouse work in 3D FPS games such as Counter Strike. 
 These previously didn't work with bongocat because these games take control of your cursor and center it on your screen.
 
-First, it detects if your mouse is being centered on your screen. If it is, then the application switches to "raw input" - relative movements of the mouse affect the position of bongocat's mouse, as opposed to the "absolute" position of your cursor. Because we can't detect if mouse has been lifted, if you let go of the mouse, the virtual mouse drifts back to the center. 
+First, it detects if your mouse is being centered on your screen. If it is, then the application switches to "raw input" - relative movements of the mouse affect the position of bongocat's mouse, as opposed to the "absolute" position of your cursor. Because we can't detect if mouse has been lifted, if you let go of the mouse, the virtual mouse drifts back to the center of the mousepad. 
 
 # Config
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository expands on [bongocat-osu ](https://github.com/kuroni/bongocat-os
 These previously didn't work with bongocat because these games take control of your cursor and center it on your screen.
 
 First, it detects if your mouse is being centered on your screen. If it is, then the application switches to "raw input" - relative movements of the mouse affect the position of bongocat's mouse, as opposed to the "absolute" position of your cursor. Because we can't detect if mouse has been lifted, if you let go of the mouse, the virtual mouse drifts back to the center of the mousepad. 
+<p align="center">
+  <img height="400" src="fps.gif">
+</p>
 
 # Config
 

--- a/include/header.hpp
+++ b/include/header.hpp
@@ -15,7 +15,7 @@
 
 #include <math.h>
 #include <string.h>
-
+#include <windows.h> 
 #include <SFML/Graphics.hpp>
 #include "json/json.h"
 
@@ -32,7 +32,8 @@ sf::Texture &load_texture(std::string path);
 }; // namespace data
 
 namespace input {
-bool init();
+void RegisterRawInputDevices(HWND hwnd);
+bool init(HINSTANCE hInstance);
 
 bool is_pressed(int key_code);
 
@@ -47,6 +48,14 @@ void drawDebugPanel();
 
 void cleanup();
 }; // namespace input
+
+namespace rawinput {
+    bool init(HINSTANCE hInstance);
+    POINT getMousePos();
+    bool isMouseBeingCentered();
+}
+
+
 
 namespace osu {
 bool init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,7 @@
 #include "header.hpp"
+#include <SFML/Graphics.hpp>
+#include <json/json.h>
+#include <iostream>
 
 #if !defined(__unix__) && !defined(__unix)
 #include <windows.h>
@@ -6,13 +9,22 @@
 
 sf::RenderWindow window;
 
+// void AttachConsole() {
+//     if (AllocConsole()) {
+//         freopen("CONOUT$", "w", stdout);  // Redirect stdout to the console
+//         freopen("CONIN$", "r", stdin);   // Redirect stdin to the console
+//         freopen("CONOUT$", "w", stderr); // Redirect stderr to the console
+//     }
+// }
+
 #if defined(__unix__) || defined(__unix)
 int main(int argc, char ** argv) {
 #else
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
-#endif
 
-    window.create(sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), "Bongo Cat for osu!", sf::Style::Titlebar | sf::Style::Close);
+    // AttachConsole();
+
+    window.create(sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), "Bongo Cat for osu!", sf::Style::Titlebar | sf::Style::Close, sf::ContextSettings(0, 0, 8));
     window.setFramerateLimit(MAX_FRAMERATE);
 
     // loading configs
@@ -21,7 +33,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
     }
 
     // initialize input
-    if (!input::init()) {
+    if (!input::init(hInstance)) {
         return EXIT_FAILURE;
     }
 
@@ -95,4 +107,4 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
     input::cleanup();
     return 0;
 }
-
+#endif

--- a/src/rawinput.cpp
+++ b/src/rawinput.cpp
@@ -1,0 +1,167 @@
+
+#include "header.hpp"
+#include <windows.h>
+#include <SFML/Window.hpp>
+
+#if !defined(__unix__) && !defined(__unix)
+
+namespace rawinput {
+
+int deltaX = 0;
+int deltaY = 0;
+POINT currentPos;
+POINT prevPos;
+int screenWidth;
+int screenHeight;
+
+const int THRESHOLD = 10;
+const int REQUIRED_FRAMES = 5;
+
+
+
+class MouseTracker {
+public:
+    MouseTracker() : frameCount(0) {}
+
+    bool isCentered() {
+        POINT cursorPos;
+        GetCursorPos(&cursorPos);
+        int screenX = (cursorPos.x / screenWidth);
+        int screenY = (cursorPos.y / screenHeight);
+
+        int centerX = (screenWidth / 2) + screenWidth * screenX;
+        int centerY = (screenHeight / 2) + screenHeight * screenY;
+
+        if (cursorPos.x >= centerX - THRESHOLD && cursorPos.x <= centerX + THRESHOLD &&
+            cursorPos.y >= centerY - THRESHOLD && cursorPos.y <= centerY + THRESHOLD) {
+            frameCount++;
+        } else {
+            frameCount = 0;
+        }
+
+        return frameCount >= REQUIRED_FRAMES;
+    }
+
+    void setWindowHandle(HWND hwnd) {
+        windowHandle = hwnd;
+    }
+
+private:
+    int frameCount;
+    HWND windowHandle;
+};
+
+
+MouseTracker mouseTracker;
+
+
+bool isMouseBeingCentered(){
+    return mouseTracker.isCentered();
+}
+
+void RegisterRawInputDevices(HWND hwnd) {
+    RAWINPUTDEVICE rid;
+    rid.usUsagePage = 0x01; // Generic desktop controls
+    rid.usUsage = 0x02; // Mouse
+    rid.dwFlags = RIDEV_INPUTSINK; // Capture input even when not in the foreground
+    rid.hwndTarget = hwnd;
+
+    if (!RegisterRawInputDevices(&rid, 1, sizeof(rid))) {
+        MessageBox(NULL, "Failed to register raw input device.", "Error", MB_OK);
+    }
+}
+
+void ProcessRawInput(LPARAM lParam) {
+    UINT dwSize = 0;
+    GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &dwSize, sizeof(RAWINPUTHEADER));
+    if (dwSize > 0) {
+        RAWINPUT* pRawInput = (RAWINPUT*)malloc(dwSize);
+        if (pRawInput) {
+            if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, pRawInput, &dwSize, sizeof(RAWINPUTHEADER)) == dwSize) {
+                if (pRawInput->header.dwType == RIM_TYPEMOUSE) {
+                    deltaX = pRawInput->data.mouse.lLastX;
+                    deltaY = pRawInput->data.mouse.lLastY;
+                }
+            }
+            free(pRawInput);
+        }
+    }
+}
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+    case WM_INPUT:
+        ProcessRawInput(lParam);
+        break;
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+
+
+bool init(HINSTANCE hInstance){
+      // rawinput window
+    WNDCLASS wc = { };
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = hInstance;
+    wc.lpszClassName = "SFMLWindowClass";
+
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowEx(0, wc.lpszClassName, "Bongo Cat for osu!", WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, NULL, NULL, hInstance, NULL);
+
+    if (hwnd == NULL) {
+        return 0;
+    }
+
+    RegisterRawInputDevices(hwnd);
+    mouseTracker.setWindowHandle(hwnd);
+    screenWidth = GetSystemMetrics(SM_CXSCREEN);
+    screenHeight = GetSystemMetrics(SM_CYSCREEN);
+    std::cout << screenWidth;
+    return 1;
+}
+
+POINT getMousePos(){
+    currentPos.x += (float)deltaX * data::cfg["decoration"]["fpsSensitivity"].asFloat();
+    currentPos.y += (float)deltaY * data::cfg["decoration"]["fpsSensitivity"].asFloat();
+    deltaX = 0;
+    deltaY = 0;
+
+    // drift the mouse towards center overtime
+    int speed = data::cfg["decoration"]["fpsReturnSpeed"].asInt();
+    if(prevPos.x == currentPos.x && prevPos.y == currentPos.y){
+        int targetX = screenWidth / 2;
+        int targetY = screenHeight / 2;
+
+        if (currentPos.x < targetX - speed - 5) {
+            currentPos.x += speed; // Move right
+        } else if (currentPos.x > targetX +  speed + 5) {
+            currentPos.x -= speed; // Move left
+        }
+
+        if (currentPos.y < targetY - speed - 5) {
+            currentPos.y += speed; // Move down
+        } else if (currentPos.y > targetY +  speed + 5) {
+            currentPos.y -= speed; // Move up
+        }
+    }
+    prevPos = currentPos;
+
+    // clamp to screen's resolution
+    currentPos.x = std::clamp((int)currentPos.x, 0, (int) screenWidth - speed - 5);
+    currentPos.y = std::clamp((int)currentPos.y, 0, (int) screenHeight - speed - 5);
+
+    return currentPos;
+}
+
+
+
+
+
+}
+#endif

--- a/src/rawinput.cpp
+++ b/src/rawinput.cpp
@@ -23,9 +23,25 @@ class MouseTracker {
 public:
     MouseTracker() : frameCount(0) {}
 
+    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+  
+
     bool isCentered() {
+        
+        HWND hwnd = GetForegroundWindow();
+        if (hwnd) {
+            RECT rcApp;
+            GetWindowRect(hwnd, &rcApp);
+            if(rcApp.right != NULL && rcApp.bottom != NULL){
+                screenWidth = rcApp.right;
+                screenHeight = rcApp.bottom;
+            }
+        }
+
         POINT cursorPos;
         GetCursorPos(&cursorPos);
+        // std::cout << screenWidth << std::endl;
         int screenX = (cursorPos.x / screenWidth);
         int screenY = (cursorPos.y / screenHeight);
 


### PR DESCRIPTION
only on windows.
description taken from my fork:

# Description

This repository expands on [bongocat-osu ](https://github.com/kuroni/bongocat-osu) by making the mouse work in 3D FPS games such as Counter Strike. 
These previously didn't work with bongocat because these games take control of your cursor and center it on your screen.

First, it detects if your mouse is being centered on your screen. If it is, then the application switches to "raw input" - relative movements of the mouse affect the position of bongocat's mouse, as opposed to the "absolute" position of your cursor. Because we can't detect if mouse has been lifted, if you let go of the mouse, the virtual mouse drifts back to the center. 

# Config

```json
"fpsSensitivity" : 2.0,
"fpsReturnSpeed" : 50
```

"fpsSensitivity" controls how fast the bongocat's mouse moves.

"fpsReturnSpeed" controls how fast the bongocat's mouse returns to the center after you let go of your mouse.
